### PR TITLE
Switch to dotenv package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"dependencies": {
 				"axios": "^1.6.7",
 				"cors": "^2.8.5",
-				"env-cmd": "^10.1.0",
+				"dotenv": "^16.4.4",
 				"eslint": "^8.56.0",
 				"mongoose": "^8.1.1",
 				"nodemon": "^3.0.3",
@@ -6824,11 +6824,14 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-			"integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+			"version": "16.4.4",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
+			"integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dotenv-expand": {
@@ -13609,6 +13612,14 @@
 				}
 			}
 		},
+		"node_modules/react-scripts/node_modules/dotenv": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+			"integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/read-cache": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15678,16 +15689,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"axios": "^1.6.7",
 		"cors": "^2.8.5",
-		"env-cmd": "^10.1.0",
+		"dotenv": "^16.4.4",
 		"eslint": "^8.56.0",
 		"mongoose": "^8.1.1",
 		"nodemon": "^3.0.3",

--- a/packages/backend/flock-services.js
+++ b/packages/backend/flock-services.js
@@ -1,8 +1,10 @@
 import mongoose from "mongoose";
 import flockModel from "./flock.js";
+import dotenv from "dotenv";
 import process from "process";
 import codeGenerator from "./code-generation/code-generator.js";
 
+dotenv.config();
 const db_password = process.env.DB_PASSWORD;
 const url = `mongodb+srv://shareduser:${db_password}@ctcluster0.6s3myd5.mongodb.net/?retryWrites=true&w=majority`;
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,13 +5,13 @@
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"dev": "env-cmd -f ./config/.env nodemon src/index.js",
-		"server": "env-cmd -f ./config/.env node src/index.js"
+		"dev": "nodemon src/index.js",
+		"server": "node src/index.js"
 	},
 	"type": "module",
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"env-cmd": "^10.1.0"
+		"dotenv": "16.4.4"
 	}
 }


### PR DESCRIPTION
Use dotenv instead of env-cmd for handling environment variables.
By prof suggestion

This requires everyone to move the .env file out of the config folder into the backend folder (and delete config folder).